### PR TITLE
Fix for #6 Fails to get gas tariffs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ PACKAGE_DIR = (HERE/"src")
 # This call to setup() does all the work
 setup(
     name="octopus-energy-client",
-    version="0.0.11",
+    version="0.0.12",
     description="A Python API for retrieving Octopus Energy data",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/src/octopus_energy_client/client.py
+++ b/src/octopus_energy_client/client.py
@@ -21,10 +21,12 @@ class OctopusEnergy:
     def __init__(
         self,
         api_key=None,
+        electricity_tariff_prefix="E-1R-",
         electricity_serial=None,
         electricity_mpan=None,
         electricity_product_code=None,
         electricity_region=None,
+        gas_tariff_prefix="G-1R-",
         gas_serial=None,
         gas_mprn=None,
         gas_product_code=None,
@@ -48,11 +50,13 @@ class OctopusEnergy:
         :param str gas_region: The region for the gas product. Default: environ['OCTOPUS_GAS_REGION']
         """        
         self.api_key = api_key or os.environ["OCTOPUS_API_KEY"]
+        self.octopus_electricity_tariff_prefix = electricity_tariff_prefix
         self.octopus_electricity_serial = electricity_serial or os.environ['OCTOPUS_ELECTRICITY_SERIAL']
         self.octopus_electricity_mpan = electricity_mpan or os.environ['OCTOPUS_ELECTRICITY_MPAN']
         self.ocopus_electricity_product_code = electricity_product_code or os.environ.get("OCTOPUS_ELECTRICITY_PRODUCT_CODE", "AGILE-18-02-21")
         self.octopus_elecricity_region = electricity_region or os.environ.get("OCTOPUS_ELECTRICITY_REGION", "C")
 
+        self.octopus_gas_tariff_prefix = gas_tariff_prefix
         self.octopus_gas_serial = gas_serial or os.environ['OCTOPUS_GAS_SERIAL']
         self.octopus_gas_mprn = gas_mprn or os.environ['OCTOPUS_GAS_MPRN']
         self.octopus_gas_product_code = gas_product_code or os.environ.get("OCTOPUS_GAS_PRODUCT_CODE", "AGILE-18-02-21")
@@ -73,6 +77,9 @@ class OctopusEnergy:
             meter_url = f"electricity-meter-points/{self.octopus_electricity_mpan}"
         elif resource_type == ResourceType.GAS:
             meter_url = f"gas-meter-points/{self.octopus_gas_mprn}"
+        else:
+            meter_url = ""
+            
         return f"{self.base_url}/{meter_url}"
 
     def tariff_url(self, resource_type):
@@ -85,9 +92,11 @@ class OctopusEnergy:
         """
 
         if resource_type == ResourceType.ELECTRICITY:
-            tariff_url = f"{self.ocopus_electricity_product_code}/electricity-tariffs/E-1R-{self.ocopus_electricity_product_code}-{self.octopus_elecricity_region}"
+            tariff_url = f"{self.ocopus_electricity_product_code}/electricity-tariffs/{self.octopus_electricity_tariff_prefix}{self.ocopus_electricity_product_code}-{self.octopus_elecricity_region}"
         elif resource_type == ResourceType.GAS:
-            tariff_url = f"{self.octopus_gas_product_code}/gas-tariffs/E-1R-{self.octopus_gas_product_code}-{self.octopus_gas_region}"
+            tariff_url = f"{self.octopus_gas_product_code}/gas-tariffs/{self.octopus_gas_tariff_prefix}{self.octopus_gas_product_code}-{self.octopus_gas_region}"
+        else:
+            tariff_url = ""
 
         return f"{self.base_url}/products/{tariff_url}"
 
@@ -103,6 +112,8 @@ class OctopusEnergy:
             serial = self.octopus_electricity_serial
         elif resource_type == ResourceType.GAS:
             serial = self.octopus_gas_serial
+        else:
+            serial = ""
 
         return f"{self.meter_url(resource_type)}/meters/{serial}/consumption"
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,10 +11,12 @@ class TestClient(unittest.TestCase):
         super().setUp()
         
         self.api_key = "123456"
+        self.electricity_tariff_prefix = "TEST-E-1R-"
         self.electricity_serial = "abc1234"
         self.electricity_mpan = "1234567890"
         self.electricity_product_code = "21JBLAH"
         self.electricity_region = "Z"
+        self.gas_tariff_prefix = "TEST-G-1R-"
         self.gas_serial = "cba4321"
         self.gas_mprn = "0987654321"
         self.gas_product_code = "12XFOO"
@@ -23,10 +25,12 @@ class TestClient(unittest.TestCase):
 
         self.client = OctopusEnergy(
             api_key=self.api_key,
+            electricity_tariff_prefix=self.electricity_tariff_prefix,
             electricity_serial=self.electricity_serial,
             electricity_mpan=self.electricity_mpan,
             electricity_product_code=self.electricity_product_code,
             electricity_region=self.electricity_region,
+            gas_tariff_prefix=self.gas_tariff_prefix,
             gas_serial=self.gas_serial,
             gas_mprn=self.gas_mprn,
             gas_product_code=self.gas_product_code,
@@ -38,8 +42,8 @@ class TestClient(unittest.TestCase):
         self.assertEqual(self.client.meter_url(ResourceType.GAS), f"{self.client.base_url}/gas-meter-points/{self.gas_mprn}")
 
     def test_tariff_url(self):
-        self.assertEqual(self.client.tariff_url(ResourceType.ELECTRICITY), f"{self.client.base_url}/products/{self.electricity_product_code}/electricity-tariffs/E-1R-{self.electricity_product_code}-{self.electricity_region}")
-        self.assertEqual(self.client.tariff_url(ResourceType.GAS), f"{self.client.base_url}/products/{self.gas_product_code}/gas-tariffs/E-1R-{self.gas_product_code}-{self.gas_region}")
+        self.assertEqual(self.client.tariff_url(ResourceType.ELECTRICITY), f"{self.client.base_url}/products/{self.electricity_product_code}/electricity-tariffs/{self.electricity_tariff_prefix}{self.electricity_product_code}-{self.electricity_region}")
+        self.assertEqual(self.client.tariff_url(ResourceType.GAS), f"{self.client.base_url}/products/{self.gas_product_code}/gas-tariffs/{self.gas_tariff_prefix}{self.gas_product_code}-{self.gas_region}")
 
     def test_consumption_url(self):
         self.assertEqual(self.client.consumption_url(ResourceType.ELECTRICITY), f"{self.client.base_url}/electricity-meter-points/{self.electricity_mpan}/meters/{self.electricity_serial}/consumption")


### PR DESCRIPTION
Fix for #6 

Added ability to specify a tariff prefix, fixed default prefix for gas tariffs to G-1R-


